### PR TITLE
be more generic

### DIFF
--- a/public_html/browserid/provision.html
+++ b/public_html/browserid/provision.html
@@ -41,7 +41,7 @@
 
           jwcrypto.cert.sign(
             {publicKey: pubkey, principal: {email: email}},
-            {issuer: 'mockmyid.com', issuedAt: now.valueOf(), expiresAt: expiration},
+            {issuer: window.location.host, issuedAt: now.valueOf(), expiresAt: expiration},
             {},
             secKey,
             function(err, signedObject) {


### PR DESCRIPTION
This one-line patch makes the code more generic: instead of using a hard-wired "mockmyid.com" issuer, it just uses window.location.host, so we could spin up alternate copies with different names easily.
